### PR TITLE
Always fallback to Deno.read*.

### DIFF
--- a/leafCompiler.ts
+++ b/leafCompiler.ts
@@ -116,7 +116,12 @@ export class Leaf {
 
         Deno.readFileSync = (path) => {
             if(globalThis["${fileSystemExecutable}"] === true) {
-                return globalThis["getFileInMem"](globalThis, path);
+                try {
+                    return globalThis["getFileInMem"](globalThis, path);
+                }
+                catch(e) {
+                    return denoApiReadFileSync(path);
+                }
             } else {
                 return denoApiReadFileSync(path);
             }


### PR DESCRIPTION
I have a hybrid application with web static content using Lead and `--allow-read` using the `pwd` for user created files.

Without this patch I cannot read those user created files.