### PR TITLE
Use the current running deno and not `which deno`

### DIFF
--- a/leafCompiler.ts
+++ b/leafCompiler.ts
@@ -145,7 +145,7 @@ export class Leaf {
         const bundleCode = (await Deno.emit(moduleToUse, { bundle: "module" })).files["deno:///bundle.js"];
         Deno.writeFileSync(tempFilePath, encoder.encode(bundleCode), { append: true });
 
-        let cmd = [Deno.execPath, "compile"];
+        let cmd = [Deno.execPath(), "compile"];
 
         if(options && options.flags) {
             if(options.flags.indexOf("--output") >= 0) throw new Error("'--output' flag is not valid in the current context. Use the property 'output' instead.");

--- a/leafCompiler.ts
+++ b/leafCompiler.ts
@@ -145,7 +145,7 @@ export class Leaf {
         const bundleCode = (await Deno.emit(moduleToUse, { bundle: "module" })).files["deno:///bundle.js"];
         Deno.writeFileSync(tempFilePath, encoder.encode(bundleCode), { append: true });
 
-        let cmd = ["deno", "compile"];
+        let cmd = [Deno.execPath, "compile"];
 
         if(options && options.flags) {
             if(options.flags.indexOf("--output") >= 0) throw new Error("'--output' flag is not valid in the current context. Use the property 'output' instead.");


### PR DESCRIPTION
I want to compile using the current running Deno.

I have a stripped deno which I want to run when doing the `Leaf.compile` step.

```typescript
  await runCmd(`cp /usr/local/bin/deno ${tempDir}/bin`);
  await runCmd(`ls -l ${tempDir}/bin/deno`);
  await runCmd(`chmod u+w ${tempDir}/bin/deno`);
  await runCmd(`strip ${tempDir}/bin/deno`);
  await runCmd(`ls -l ${tempDir}/bin/deno`);
```