### PR TITLE
Code clean up, & update to latest version of Deno.

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -1,3 +1,3 @@
-export const fileSystemPropertyName: string = "MANDARINE_FILE_SYSTEM";
-export const fileSystemExecutable: string = "MANDARINE_FILE_SYSTEM_IS_EXECUTABLE";
-export const fileSystemExecutableGetter: string = "__MANDARINE_FILE_SYSTEM_GET__";
+export const fileSystemPropertyName = "MANDARINE_FILE_SYSTEM";
+export const fileSystemExecutable = "MANDARINE_FILE_SYSTEM_IS_EXECUTABLE";
+export const fileSystemExecutableGetter = "__MANDARINE_FILE_SYSTEM_GET__";

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,2 @@
+export { walkSync } from 'https://deno.land/std@0.197.0/fs/mod.ts';
+export { bundle } from 'https://deno.land/x/emit@0.25.0/mod.ts';

--- a/functions/getFileInMem.ts
+++ b/functions/getFileInMem.ts
@@ -1,7 +1,7 @@
-import { MemMethods } from "./methods.ts";
+import { MemMethods } from './methods.ts';
 
-export const MANDARINE_GET_FILE_IN_MEM = (globalThis: MemMethods, path: string | URL, isExecutable: boolean): Uint8Array => {
-    let filePath = globalThis["getFilePath"](path);
+export const MANDARINE_GET_FILE_IN_MEM = (globalThis: MemMethods, path: string | URL): Uint8Array => {
+    const filePath = globalThis["getFilePath"](path);
 
     if(!filePath) throw new Error("Invalid Path");
 


### PR DESCRIPTION
Wanted to use this library, and seems not much has changed recently. 

- Removed `Deno.emit` as deprecated, and now use `bundle` from `emit` library.
- Replaced `Deno.run` as that will be deprecated in Deno 2.0, now using `Deno.Command`
- Updated unit tests to the latest dependencies, and previous changes. 
- Added `deps.ts` file for import/export of libraries dependencies.
- Slight code clean up to stop linter yelling. 


_Note: Only tested on Linux (Ubuntu)_ 